### PR TITLE
Update DataBoundFormComponent.cs

### DIFF
--- a/Radzen.Blazor/DataBoundFormComponent.cs
+++ b/Radzen.Blazor/DataBoundFormComponent.cs
@@ -187,8 +187,6 @@ namespace Radzen
             {
                 if (_data != value)
                 {
-                    _view = null;
-                    _value = null;
                     _data = value;
                     StateHasChanged();
                 }


### PR DESCRIPTION
Removed code that breaks the logic of dynamic data loading

Provided that the data changes, the entire value field is cleared, ultimately this breaks the possibility of implementing auto completion with dynamic data loading using the MVVC pattern, where it is impossible to load data from the context inside the ViewModel using LoadData